### PR TITLE
V1.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Hikka Changelog
 
+## 🌑 Hikka 1.2.12
+
+- Automatically patch reply markup in inline form in the way, that edit stays available anyway
+- Do not unload inline form automatically, keep it for 10 minutes instead
+- Use `telethon.utils.resolve_inline_message_id` to remove inline unit
+- Add `self.request_join`
+- Allow developers to declare `client_ready` without arguments
+
 ## 🌑 Hikka 1.2.11
 
 - Add support for lib attribute `version` (must be defined BEFORE `init` method)

--- a/hikka/forbid_joins.py
+++ b/hikka/forbid_joins.py
@@ -46,25 +46,38 @@ def install_join_forbidder(client: TelegramClient) -> TelegramClient:
 
         for item in request:
             if item.CONSTRUCTOR_ID in {615851205, 1817183516}:
-                try:
-                    if next(
+                if next(
+                    (
                         frame_info.frame.f_locals["self"]
                         for frame_info in inspect.stack()
                         if hasattr(frame_info, "frame")
                         and hasattr(frame_info.frame, "f_locals")
                         and isinstance(frame_info.frame.f_locals, dict)
                         and "self" in frame_info.frame.f_locals
-                        and isinstance(frame_info.frame.f_locals["self"], loader.Module)
-                        and frame_info.frame.f_locals["self"].__class__.__name__
-                        not in {"APIRatelimiterMod", "ForbidJoinMod"}
-                    ).__class__.__name__ not in {"HelpMod", "LoaderMod"}:
-                        logger.debug(
-                            "🎉 I protected you from unintented"
-                            f" {item.__class__.__name__} ({item})!"
+                        and isinstance(
+                            frame_info.frame.f_locals["self"], loader.Module
                         )
-                        continue
-                except StopIteration:
-                    pass
+                        and frame_info.frame.f_locals["self"].__class__.__name__
+                        not in {
+                            "APIRatelimiterMod",
+                            "ForbidJoinMod",
+                            "HelpMod",
+                            "LoaderMod",
+                            "HikkaSettingsMod",
+                        }
+                        # APIRatelimiterMod is a core proxy, so it wraps around every module in Hikka, if installed
+                        # ForbidJoinMod is also a Core proxy, so it wraps around every module in Hikka, if installed
+                        # HelpMod uses JoinChannelRequest for .support command
+                        # LoaderMod prompts user to join developers' channels
+                        # HikkaSettings prompts user to join channels, required by modules
+                    ),
+                    None,
+                ):
+                    logger.debug(
+                        "🎉 I protected you from unintented"
+                        f" {item.__class__.__name__} ({item})!"
+                    )
+                    continue
 
             new_request += [item]
 

--- a/hikka/inline/bot_pm.py
+++ b/hikka/inline/bot_pm.py
@@ -7,11 +7,11 @@
 # 🌐 https://www.gnu.org/licenses/agpl-3.0.html
 
 import logging
-from typing import Optional, Union
 
 from aiogram.types import Message as AiogramMessage
-
+from typing import Optional, Union
 from .types import InlineUnit
+
 
 logger = logging.getLogger(__name__)
 

--- a/hikka/inline/form.py
+++ b/hikka/inline/form.py
@@ -53,6 +53,10 @@ VERIFICATION_EMOJIES = list(
 )
 
 
+class Placeholder:
+    """Placeholder"""
+
+
 class Form(InlineUnit):
     async def form(
         self,
@@ -239,10 +243,10 @@ class Form(InlineUnit):
             and not ttl
         ):
             logger.debug("Patching form reply markup with empty data")
-            base_reply_markup = reply_markup.copy()
+            base_reply_markup = copy.deepcopy(reply_markup) or None
             reply_markup = self._validate_markup({"text": "­", "data": "­"})
         else:
-            base_reply_markup = None
+            base_reply_markup = Placeholder()
 
         if (
             not any(
@@ -332,7 +336,7 @@ class Form(InlineUnit):
 
         msg = InlineMessage(self, unit_id, inline_message_id)
 
-        if base_reply_markup:
+        if not isinstance(base_reply_markup, Placeholder):
             await msg.edit(text, reply_markup=base_reply_markup)
 
         return msg

--- a/hikka/inline/utils.py
+++ b/hikka/inline/utils.py
@@ -40,6 +40,8 @@ from .. import utils
 from .._types import Module
 from .types import InlineUnit, InlineCall
 
+from telethon.utils import resolve_inline_message_id
+
 logger = logging.getLogger(__name__)
 
 
@@ -512,11 +514,11 @@ class Utils(InlineUnit):
             unit_id = call.unit_id
 
         try:
-            await self._client.delete_messages(
-                self._units[unit_id]["chat"],
-                [self._units[unit_id]["message_id"]],
+            message_id, peer, _, _ = resolve_inline_message_id(
+                self._units[unit_id]["inline_message_id"]
             )
 
+            await self._client.delete_messages(peer, [message_id])
             await self._unload_unit(None, unit_id)
         except Exception:
             return False

--- a/hikka/loader.py
+++ b/hikka/loader.py
@@ -730,6 +730,11 @@ class Modules:
 
         channel = await self.client.get_entity(peer)
         if channel.id in self._db.get("hikka.main", "declined_joins", []):
+            if assure_joined:
+                raise LoadError(
+                    f"You need to join @{channel.username} in order to use this module"
+                )
+            
             return False
 
         if not isinstance(channel, Channel):

--- a/hikka/modules/hikka_settings.py
+++ b/hikka/modules/hikka_settings.py
@@ -18,6 +18,7 @@ from telethon.tl.functions.messages import (
     GetDialogFiltersRequest,
     UpdateDialogFilterRequest,
 )
+from telethon.tl.functions.channels import JoinChannelRequest
 from telethon.utils import get_display_name
 
 from .. import loader, main, utils
@@ -238,7 +239,7 @@ class HikkaSettingsMod(loader.Module):
         async with self._client.conversation("@BotFather") as conv:
             for msg in [
                 "/deletebot",
-                self.inline.bot_username,
+                f"@{self.inline.bot_username}",
                 "Yes, I am totally sure.",
             ]:
                 m = await conv.send_message(msg)
@@ -953,3 +954,21 @@ class HikkaSettingsMod(loader.Module):
             reply_markup={"text": self.strings("web_btn"), "url": url},
             gif="https://t.me/hikari_assets/28",
         )
+
+    @loader.loop(interval=1, autostart=True)
+    async def loop(self):
+        obj = self.allmodules.get_approved_channel
+        if not obj:
+            return
+
+        channel, event = obj
+
+        try:
+            await self._client(JoinChannelRequest(channel))
+        except Exception:
+            logger.exception("Failed to join channel")
+            event.status = False
+            event.set()
+        else:
+            event.status = True
+            event.set()

--- a/hikka/version.py
+++ b/hikka/version.py
@@ -1,2 +1,2 @@
 """Represents current userbot version"""
-__version__ = (1, 2, 11)
+__version__ = (1, 2, 12)


### PR DESCRIPTION
- Automatically patch reply markup in inline form in the way, that edit stays available anyway
- Do not unload inline form automatically, keep it for 10 minutes instead
- Use `telethon.utils.resolve_inline_message_id` to remove inline unit
- Add `self.request_join`
- Allow developers to declare `client_ready` without arguments