### PR TITLE
V1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Hikka Changelog
 
+## 🌑 Hikka 1.5.1
+
+- Fix `--no-web` arg
+- Fix `tglog_level` config option of module `Tester`
+- Add `--proxy-pass` arg
+- Add `utils.invite_inline_bot` method
+- Add `invite_bot` method to `utils.asset_channel`
+- Add support for `String` validator's `min_len` and `max_len` parameters
+
 ## 🌑 Hikka 1.5.0
 
 - Fix `on_change` param processing in config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@
 - Fix `--no-web` arg
 - Fix `tglog_level` config option of module `Tester`
 - Fix duplicated monkey on login page
+- Fix shit modules with uppercase commands
 - Add physical `Enter` button to login page on mobile devices
 - Add `--proxy-pass` arg
 - Add `utils.invite_inline_bot` method
-- Add `invite_bot` method to `utils.asset_channel`
+- Add `utils.iter_attrs` method
+- Add `@loader.raw_handler` decorator
+- Add `invite_bot` parameter to `utils.asset_channel`
 - Add support for `String` validator's `min_len` and `max_len` parameters
 
 ## 🌑 Hikka 1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix `--no-web` arg
 - Fix `tglog_level` config option of module `Tester`
+- Fix duplicated monkey on login page
+- Add physical `Enter` button to login page on mobile devices
 - Add `--proxy-pass` arg
 - Add `utils.invite_inline_bot` method
 - Add `invite_bot` method to `utils.asset_channel`

--- a/hikka/configurator.py
+++ b/hikka/configurator.py
@@ -77,25 +77,25 @@ else:
 def api_config(data_root: str):
     """Request API config from user and set"""
     code, hash_value = DIALOG.inputbox("Enter your API Hash")
-    if code == DIALOG.OK:
-        if len(hash_value) != 32 or any(
-            it not in string.hexdigits for it in hash_value
-        ):
-            DIALOG.msgbox("Invalid hash")
-            return
+    if not code:
+        return
 
-        code, id_value = DIALOG.inputbox("Enter your API ID")
+    if len(hash_value) != 32 or any(it not in string.hexdigits for it in hash_value):
+        DIALOG.msgbox("Invalid hash")
+        return
 
-        if not id_value or any(it not in string.digits for it in id_value):
-            DIALOG.msgbox("Invalid ID")
-            return
+    code, id_value = DIALOG.inputbox("Enter your API ID")
 
-        with open(
-            os.path.join(
-                data_root or os.path.dirname(utils.get_base_dir()), "api_token.txt"
-            ),
-            "w",
-        ) as file:
-            file.write(id_value + "\n" + hash_value)
+    if not id_value or any(it not in string.digits for it in id_value):
+        DIALOG.msgbox("Invalid ID")
+        return
 
-        DIALOG.msgbox("API Token and ID set.")
+    with open(
+        os.path.join(
+            data_root or os.path.dirname(utils.get_base_dir()), "api_token.txt"
+        ),
+        "w",
+    ) as file:
+        file.write(id_value + "\n" + hash_value)
+
+    DIALOG.msgbox("API Token and ID set.")

--- a/hikka/dispatcher.py
+++ b/hikka/dispatcher.py
@@ -108,6 +108,8 @@ class CommandDispatcher:
             else str(self._client.hikka_me.id)
         )
 
+        self.raw_handlers = []
+
     async def _handle_ratelimit(self, message: Message, func: callable) -> bool:
         if await self.security.check(
             message,
@@ -369,6 +371,15 @@ class CommandDispatcher:
             message = self._handle_grep(message)
 
         return message, prefix, txt, func
+
+    async def handle_raw(self, event: events.Raw):
+        """Handle raw events."""
+        for handler in self.raw_handlers:
+            if isinstance(event, tuple(handler.updates)):
+                try:
+                    await handler(event)
+                except Exception as e:
+                    logger.exception("Error in raw handler %s: %s", handler.id, e)
 
     async def handle_command(
         self,

--- a/hikka/main.py
+++ b/hikka/main.py
@@ -620,6 +620,11 @@ class Hikka:
             events.MessageEdited(),
         )
 
+        client.add_event_handler(
+            dispatcher.handle_raw,
+            events.Raw(),
+        )
+
     async def amain(self, first: bool, client: CustomTelegramClient):
         """Entrypoint for async init, run once for each user"""
         client.parse_mode = "HTML"

--- a/hikka/main.py
+++ b/hikka/main.py
@@ -215,6 +215,12 @@ def parse_arguments() -> dict:
         action="store_true",
         help="Disable `force_insecure` warning",
     )
+    parser.add_argument(
+        "--proxy-pass",
+        dest="proxy_pass",
+        action="store_true",
+        help="Open proxy pass tunnel on start (not needed on setup)",
+    )
     arguments = parser.parse_args()
     logging.debug(arguments)
     if sys.platform == "win32":
@@ -636,6 +642,7 @@ class Hikka:
             await self.web.start_if_ready(
                 len(self.clients),
                 self.arguments.port,
+                proxy_pass=self.arguments.proxy_pass,
             )
 
         await self._add_dispatcher(client, modules, db)

--- a/hikka/types.py
+++ b/hikka/types.py
@@ -370,7 +370,7 @@ def _get_members(
             method_name.rsplit(ending, maxsplit=1)[0]
             if (method_name == ending if strict else method_name.endswith(ending))
             else method_name
-        ): getattr(mod, method_name)
+        ).lower(): getattr(mod, method_name)
         for method_name in dir(mod)
         if callable(getattr(mod, method_name))
         and (

--- a/hikka/utils.py
+++ b/hikka/utils.py
@@ -1394,6 +1394,15 @@ def validate_html(html: str) -> str:
     return telethon.extensions.html.unparse(escape_html(text), entities)
 
 
+def iter_attrs(obj: typing.Any, /) -> typing.Iterator[typing.Tuple[str, typing.Any]]:
+    """
+    Iterates over attributes of object
+    :param obj: Object to iterate over
+    :return: Iterator of attributes and their values
+    """
+    return ((attr, getattr(obj, attr)) for attr in dir(obj))
+
+
 init_ts = time.perf_counter()
 
 

--- a/hikka/utils.py
+++ b/hikka/utils.py
@@ -25,6 +25,7 @@
 # 🌐 https://www.gnu.org/licenses/agpl-3.0.html
 
 import asyncio
+import contextlib
 import functools
 import io
 import json
@@ -47,7 +48,12 @@ import telethon
 from telethon import hints
 from telethon.tl.custom.message import Message
 from telethon.tl.functions.account import UpdateNotifySettingsRequest
-from telethon.tl.functions.channels import CreateChannelRequest, EditPhotoRequest
+from telethon.tl.functions.channels import (
+    CreateChannelRequest,
+    EditPhotoRequest,
+    EditAdminRequest,
+    InviteToChannelRequest,
+)
 from telethon.tl.functions.messages import (
     GetDialogFiltersRequest,
     UpdateDialogFilterRequest,
@@ -82,6 +88,7 @@ from telethon.tl.types import (
     User,
     Chat,
     UpdateNewChannelMessage,
+    ChatAdminRights,
 )
 
 from aiogram.types import Message as AiogramMessage
@@ -633,6 +640,36 @@ async def set_avatar(
     return True
 
 
+async def invite_inline_bot(
+    client: CustomTelegramClient,
+    peer: hints.EntityLike,
+) -> None:
+    """
+    Invites inline bot to a chat
+    :param client: Client to use
+    :param peer: Peer to invite bot to
+    :return: None
+    :raise RuntimeError: If error occurred while inviting bot
+    """
+
+    try:
+        await client(InviteToChannelRequest(peer, [client.loader.inline.bot_username]))
+    except Exception as e:
+        raise RuntimeError(
+            "Can't invite inline bot to old asset chat, which is required by module"
+        ) from e
+
+    with contextlib.suppress(Exception):
+        await client(
+            EditAdminRequest(
+                channel=peer,
+                user_id=client.loader.inline.bot_username,
+                admin_rights=ChatAdminRights(ban_users=True),
+                rank="Hikka",
+            )
+        )
+
+
 async def asset_channel(
     client: CustomTelegramClient,
     title: str,
@@ -641,6 +678,7 @@ async def asset_channel(
     channel: bool = False,
     silent: bool = False,
     archive: bool = False,
+    invite_bot: bool = False,
     avatar: typing.Optional[str] = None,
     ttl: typing.Optional[int] = None,
     _folder: typing.Optional[str] = None,
@@ -653,6 +691,7 @@ async def asset_channel(
     :param channel: Whether to create a channel or supergroup
     :param silent: Automatically mute channel
     :param archive: Automatically archive channel
+    :param invite_bot: Add inline bot and assure it's in chat
     :param avatar: Url to an avatar to set as pfp of created peer
     :param ttl: Time to live for messages in channel
     :return: Peer and bool: is channel new or pre-existent
@@ -669,6 +708,15 @@ async def asset_channel(
     async for d in client.iter_dialogs():
         if d.title == title:
             client._channels_cache[title] = {"peer": d.entity, "exp": int(time.time())}
+            if invite_bot:
+                if all(
+                    participant.id != client.loader.inline.bot_id
+                    for participant in (
+                        await client.get_participants(d.entity, limit=100)
+                    )
+                ):
+                    await invite_inline_bot(client, d.entity)
+
             return d.entity, False
 
     peer = (
@@ -680,6 +728,9 @@ async def asset_channel(
             )
         )
     ).chats[0]
+
+    if invite_bot:
+        await invite_inline_bot(client, peer)
 
     if silent:
         await dnd(client, peer, archive)

--- a/hikka/validators.py
+++ b/hikka/validators.py
@@ -462,6 +462,22 @@ class String(Validator):
                 f"Passed value ({value}) must be a length of {length}"
             )
 
+        if (
+            isinstance(min_len, int)
+            and len(list(grapheme.graphemes(str(value)))) < min_len
+        ):
+            raise ValidationError(
+                f"Passed value ({value}) must be a length of at least {min_len}"
+            )
+
+        if (
+            isinstance(max_len, int)
+            and len(list(grapheme.graphemes(str(value)))) > max_len
+        ):
+            raise ValidationError(
+                f"Passed value ({value}) must be a length of up to {max_len}"
+            )
+
         return str(value)
 
 

--- a/hikka/version.py
+++ b/hikka/version.py
@@ -1,5 +1,5 @@
 """Represents current userbot version"""
-__version__ = (1, 5, 0)
+__version__ = (1, 5, 1)
 
 import git
 import os

--- a/hikka/web/core.py
+++ b/hikka/web/core.py
@@ -65,10 +65,15 @@ class Web(root.Web):
         self.app.router.add_get("/favicon.ico", self.favicon)
         self.app.router.add_static("/static/", "web-resources/static")
 
-    async def start_if_ready(self, total_count: int, port: int):
+    async def start_if_ready(
+        self,
+        total_count: int,
+        port: int,
+        proxy_pass: bool = False,
+    ):
         if total_count <= len(self.client_data):
             if not self.running.is_set():
-                await self.start(port)
+                await self.start(port, proxy_pass=proxy_pass)
 
             self.ready.set()
 

--- a/web-resources/root.jinja2
+++ b/web-resources/root.jinja2
@@ -33,7 +33,8 @@
   <div id="monkey"></div>
   <div id="monkey-close"></div>
   <span class="code-caption">Enter the code you recieved from Telegram</span>
-  <input type="text" class="code-input" inputmode="numeric" autocomplete="off">
+  <input type="text" class="code-input" autocomplete="off">
+  <div class="enter">Enter</div>
 </div>
 <div class="wrapper">
   <div class="blur main finish_block">

--- a/web-resources/static/base.css
+++ b/web-resources/static/base.css
@@ -596,7 +596,44 @@ label {
     text-align: center;
 }
 
-#monkey, #monkey-close {
+@media screen and (max-width: 736px) {
+    .auth-code-form {
+        width: 100%;
+        height: 100%;
+    }
+}
+
+.enter {
+    padding: 5px 10px;
+    border: 1px solid #dc137b;
+    color: #dc137b;
+    font-size: 30px;
+    border-radius: 8px;
+    width: 50%;
+    margin-left: 25%;
+    margin-top: 10px;
+    box-sizing: border-box;
+    transition: all .15s ease;
+    display: none;
+}
+
+@media screen and (max-width: 736px) {
+    .enter {
+        display: block;
+    }
+}
+
+.enter.tgcode {
+    display: none;
+}
+
+.enter:active {
+    background: #dc137b;
+    color: #fff;
+}
+
+#monkey,
+#monkey-close {
     height: 200px;
     margin-top: 30px;
 }

--- a/web-resources/static/root.js
+++ b/web-resources/static/root.js
@@ -116,7 +116,7 @@ function tg_code() {
             if (!response.ok) {
                 if (response.status == 401) {
                     $(".auth-code-form").hide().fadeIn(300, () => {
-                        $("#monkey-close").html();
+                        $("#monkey-close").html("");
                         anim = bodymovin.loadAnimation({
                             container: document.getElementById("monkey-close"),
                             renderer: "canvas",
@@ -134,6 +134,9 @@ function tg_code() {
                         })
                     });
                     $(".code-input").removeAttr("disabled");
+                    $(".code-input").attr("inputmode", "text");
+                    if($(".enter").hasClass("tgcode"))
+                        $(".enter").removeClass("tgcode");
                     $(".code-caption").html("Enter your Telegram 2FA password, then press <span style='color: #dc137b;'>Enter</span>");
                     cnt_btn.setAttribute("current-step", "2fa");
                     $("#monkey").hide();
@@ -271,7 +274,7 @@ function process_next() {
                     });
                 } else {
                     $(".auth-code-form").hide().fadeIn(300, () => {
-                        $("#monkey").html();
+                        $("#monkey").html("");
                         anim2 = bodymovin.loadAnimation({
                             container: document.getElementById("monkey"),
                             renderer: "canvas",
@@ -289,6 +292,7 @@ function process_next() {
                         })
                     });
                     $(".code-input").removeAttr("disabled");
+                    $(".enter").addClass("tgcode");
                     $(".code-caption").text("Enter the code you recieved in Telegram");
                     cnt_btn.setAttribute("current-step", "code");
                     _current_block = "code";
@@ -376,6 +380,16 @@ $(".code-input").on("keyup", (e) => {
         $(".code-input").val("");
         tg_code();
     } else if (_current_block == "2fa" && (e.key === "Enter" || e.keyCode === 13)) {
+        let _2fa = $(".code-input").val();
+        _2fa_pass = _2fa;
+        $(".code-input").attr("disabled", "true");
+        $(".code-input").val("");
+        tg_code();
+    }
+});
+
+$(".enter").on("click", () => {
+    if (_current_block == "2fa") {
         let _2fa = $(".code-input").val();
         _2fa_pass = _2fa;
         $(".code-input").attr("disabled", "true");


### PR DESCRIPTION
- Fix `--no-web` arg
- Fix `tglog_level` config option of module `Tester`
- Fix duplicated monkey on login page
- Fix shit modules with uppercase commands
- Add physical `Enter` button to login page on mobile devices
- Add `--proxy-pass` arg
- Add `utils.invite_inline_bot` method
- Add `utils.iter_attrs` method
- Add `@loader.raw_handler` decorator
- Add `invite_bot` parameter to `utils.asset_channel`
- Add support for `String` validator's `min_len` and `max_len` parameters