### PR TITLE
1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hikka Changelog
 
+## 🌑 Hikka 1.5.2
+
+- Change the behavior of `@loader.raw_handler` decorator to accept starred arguments instead of list-like value
+
 ## 🌑 Hikka 1.5.1
 
 - Fix `--no-web` arg

--- a/hikka/loader.py
+++ b/hikka/loader.py
@@ -503,7 +503,7 @@ def callback_handler(*args, **kwargs):
     return _mark_method("is_callback_handler", *args, **kwargs)
 
 
-def raw_handler(updates: typing.Union[TLObject, typing.List[TLObject]]):
+def raw_handler(*updates: TLObject):
     """
     Decorator that marks function as raw telethon events handler
     Use it to prevent zombie-event-handlers, left by unloaded modules
@@ -511,8 +511,6 @@ def raw_handler(updates: typing.Union[TLObject, typing.List[TLObject]]):
     ⚠️ Do not try to simulate behavior of this decorator by yourself!
     ⚠️ This feature won't work, if you dynamically declare method with decorator!
     """
-    if not is_list_like(updates):
-        updates = [updates]
 
     def inner(func: callable):
         func.is_raw_handler = True

--- a/hikka/version.py
+++ b/hikka/version.py
@@ -1,5 +1,5 @@
 """Represents current userbot version"""
-__version__ = (1, 5, 1)
+__version__ = (1, 5, 2)
 
 import git
 import os


### PR DESCRIPTION
- Change the behavior of `@loader.raw_handler` decorator to accept starred arguments instead of list-like value