### PR TITLE
Remove adware

### DIFF
--- a/hikka/loader.py
+++ b/hikka/loader.py
@@ -914,11 +914,8 @@ class Modules:
         Request to join a channel.
         :param peer: The channel to join.
         :param reason: The reason for joining.
-        :param assure_joined: If set, module will not be loaded unless the required channel is joined.
-                              ⚠️ Works only in `client_ready`!
-                              ⚠️ If user declines to join channel, he will not be asked to
-                              join again, so unless he joins it manually, module will not be loaded
-                              ever.
+        :param assure_joined: does literally NOTHING
+
         :return: Status of the request.
         :rtype: bool
         :notice: This method will block module loading until the request is approved or declined.
@@ -933,10 +930,6 @@ class Modules:
 
         channel = await self.client.get_entity(peer)
         if channel.id in self._db.get("hikka.main", "declined_joins", []):
-            if assure_joined:
-                raise LoadError(
-                    f"You need to join @{channel.username} in order to use this module"
-                )
 
             return False
 
@@ -995,11 +988,6 @@ class Modules:
 
         with contextlib.suppress(AttributeError):
             delattr(_module, "hikka_wait_channel_approve")
-
-        if assure_joined and not event.status:
-            raise LoadError(
-                f"You need to join @{channel.username} in order to use this module"
-            )
 
         return event.status
 

--- a/hikka/modules/hikka_settings.py
+++ b/hikka/modules/hikka_settings.py
@@ -2291,10 +2291,6 @@ class HikkaSettingsMod(loader.Module):
             gif="https://t.me/hikari_assets/48",
         )
 
-    @loader.loop(interval=1, autostart=True)
-    async def loop(self):
-        return
-
     def _get_all_IDM(self, module: str):
         return {
             getattr(getattr(self.lookup(module), name), "name", name): getattr(

--- a/hikka/modules/hikka_settings.py
+++ b/hikka/modules/hikka_settings.py
@@ -18,7 +18,6 @@ from telethon.tl.functions.messages import (
     GetDialogFiltersRequest,
     UpdateDialogFilterRequest,
 )
-from telethon.tl.functions.channels import JoinChannelRequest
 from telethon.utils import get_display_name
 
 from .. import loader, main, utils
@@ -2294,21 +2293,7 @@ class HikkaSettingsMod(loader.Module):
 
     @loader.loop(interval=1, autostart=True)
     async def loop(self):
-        obj = self.allmodules.get_approved_channel
-        if not obj:
-            return
-
-        channel, event = obj
-
-        try:
-            await self._client(JoinChannelRequest(channel))
-        except Exception:
-            logger.exception("Failed to join channel")
-            event.status = False
-            event.set()
-        else:
-            event.status = True
-            event.set()
+        return
 
     def _get_all_IDM(self, module: str):
         return {

--- a/hikka/types.py
+++ b/hikka/types.py
@@ -84,8 +84,6 @@ class Module:
         Called after the module is first time loaded with .dlmod or .loadmod
 
         Possible use-cases:
-        - Send reaction to author's channel message
-        - Join author's channel
         - Create asset folder
         - ...
 


### PR DESCRIPTION
Since the Hikka userbot is based on FTG, GeekTG, etc., and there are no so-called "advertising Trojans" in them, it also shouldn’t have functions that make the user a slave of his own bot, forcing him to subscribe to the channel to install module and automatically putting reactions to posts with modules in the developer channel of these modules.

**This functionality isn’t spelled out anywhere** (for the end user), except in the code and changelogs, therefore **he does not even think about it when he installs the bot according to the instructions**.

**Based on the absence of this functionality in other userbots** on which Hikka is based, you should equate them and not add functionality **hidden** from the end user without notifying him in advance even before installing the userbot, or notify the user of the presence of such functionality in any most noticeable way, or implement the possibility of disabling this functionality if user doesn't want to subscribe on any channels, and even more so doesn’t want to put reactions without knowing it.