### PR TITLE
Auto push to docker hub images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platform: linux/amd64,linux/arm64/v8,linux/arm/v7
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/hikka:latest
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,33 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/hikka:latest
+

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platform: linux/amd64,linux/arm64/v8,linux/arm/v7
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/hikka:latest
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,6 +13,11 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+      - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64,arm'
       -
         name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+          platforms: linux/arm64/v8
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/hikka:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN groupadd -g 10001 user && \
 
 USER user
 
-CMD python -m hikka
+CMD python -m hikka --port 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.8-slim as python-base
-ENV DOCKER=true
+#ENV DOCKER=true
 ENV GIT_PYTHON_REFRESH=quiet
 
 ENV PIP_NO_CACHE_DIR=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.8-slim as python-base
+
 #ENV DOCKER=true
 ENV GIT_PYTHON_REFRESH=quiet
 
@@ -17,20 +18,20 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     neofetch \
     && rm -rf /var/lib/apt/lists/*
-
+    
 RUN mkdir /data
 
 COPY . /data/Hikka
 WORKDIR /data/Hikka
 
+RUN groupadd -g 10001 user && \
+   useradd -u 10000 -g user user \
+   && chown -R user:user /data
+
+USER user
+
 RUN pip install --no-warn-script-location --no-cache-dir -U -r requirements.txt
 
 EXPOSE 8080
-
-RUN groupadd -g 10001 user && \
-   useradd -u 10000 -g user user \
-   && chown -R user:user /data/Hikka
-
-USER user
 
 CMD python -m hikka --port 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ RUN pip install --no-warn-script-location --no-cache-dir -U -r requirements.txt
 
 EXPOSE 8080
 
+RUN groupadd -g 10001 user && \
+   useradd -u 10000 -g user user \
+   && chown -R user:user /data/Hikka
+
 USER user
 
 CMD python -m hikka

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,15 @@ ENV PIP_NO_CACHE_DIR=1 \
 RUN apt update && apt install libcairo2 git build-essential -y --no-install-recommends
 RUN rm -rf /var/lib/apt/lists /var/cache/apt/archives /tmp/*
 
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    build-essential  \
+    gcc \
+    python3-dev \
+    neofetch \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /data
 
 COPY . /data/Hikka
@@ -17,5 +26,7 @@ WORKDIR /data/Hikka
 RUN pip install --no-warn-script-location --no-cache-dir -U -r requirements.txt
 
 EXPOSE 8080
+
+USER user
 
 CMD python -m hikka


### PR DESCRIPTION
# Change log
![изображение](https://github.com/hikariatama/Hikka/assets/60792943/9227257a-e37c-4f85-9eeb-23c358ef3367)

Each commit on the main branch is followed by an update of the image version on the Docker Hub.

Build on multiple platforms for convenience.

Example use:
```
docker pull vsecoder/hikka:latest
docker run --name hikka -p 1234:8080 -it vsecoder/hikka:latest 
```

# Recommended
1. Edit 36 line in workflow file, this build platforms.
2. Pls, fix installer