### PR TITLE
Fix UnicodeDecodeError in Windows

### DIFF
--- a/hikka/translations.py
+++ b/hikka/translations.py
@@ -49,7 +49,7 @@ class BaseTranslator:
         pack: Path,
         prefix: str = "hikka.modules.",
     ) -> typing.Optional[dict]:
-        return self._get_pack_raw(pack.read_text(), pack.suffix, prefix)
+        return self._get_pack_raw(pack.read_text(encoding='utf-8'), pack.suffix, prefix)
 
     def _get_pack_raw(
         self,


### PR DESCRIPTION
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 135: character maps to <undefined>
In Windows

https://imgur.com/WEhGRYL